### PR TITLE
Added write callback in order to listen for write requests.

### DIFF
--- a/src/JAXL/jaxl.php
+++ b/src/JAXL/jaxl.php
@@ -434,12 +434,6 @@ class JAXL extends XMPPStream
         $this->start();
     }
 
-    //called back when we want to get the next batch
-    public function process_next_batch() {
-        JAXLLogger::debug("NEXT BATCH CALLED");
-        $this->ev->emit('get_next_batch');
-    }
-
     public function start(array $opts = array())
     {
         // is bosh bot?
@@ -486,10 +480,7 @@ class JAXL extends XMPPStream
                 $this->enable_unix_sock();
             }
 
-            if ($this->cfg["batched_data"]) {
-                //set the callback for our data checks, time in microseconds
-                JAXLLoop::set_next_batch_cb(array(&$this, 'process_next_batch'), 2000000);
-            }
+            JAXLLoop::set_write_callback(array($this, 'write'));
             
             // run main loop
             JAXLLoop::run();
@@ -871,5 +862,10 @@ class JAXL extends XMPPStream
                 //    ', node:'.(isset($child->attrs['node']) ? $child->attrs['node'] : 'NULL').PHP_EOL;
             }
         }
+    }
+
+    public function write()
+    {
+        $this->ev->emit('on_write');
     }
 }


### PR DESCRIPTION
When JAXL is started it runs in an infinite loop, until there are no more active read/write file descriptors. Reading is fine because stream remains opened and data can come easily. However, writing is not that easy: you need to call `send()` in order to initiate writing data.

This PR adds ability to register your own write callback. It's being invoked on every loop cycle (the same as read callbacks) and it allows you to send data from your code.

Prior to this PR once connection is established you could only listed for incoming requests, and then respond to them. With this PR now you can write data without the need to wait for incoming message first.