### PR TITLE
Improved logging

### DIFF
--- a/src/JAXL/core/jaxl_logger.php
+++ b/src/JAXL/core/jaxl_logger.php
@@ -75,14 +75,14 @@ class JAXLLogger
 
     public static function log($msg, $verbosity = self::ERROR)
     {
+        $bt = debug_backtrace();
+        array_shift($bt);
+        $callee = array_shift($bt);
+        $msg = basename($callee['file'], '.php').":".$callee['line']." - ".@date('Y-m-d H:i:s')." - ".$msg;
+
         self::getPsr3Logger()->log(self::$psr3LogLevelMap[$verbosity], $msg);
 
         if ($verbosity <= self::$level) {
-            $bt = debug_backtrace();
-            array_shift($bt);
-            $callee = array_shift($bt);
-            $msg = basename($callee['file'], '.php').":".$callee['line']." - ".@date('Y-m-d H:i:s')." - ".$msg;
-
             $size = strlen($msg);
             if ($size > self::$max_log_size) {
                 $msg = substr($msg, 0, self::$max_log_size) . ' ...';

--- a/src/JAXL/core/jaxl_socket_client.php
+++ b/src/JAXL/core/jaxl_socket_client.php
@@ -62,9 +62,6 @@ class JAXLSocketClient implements JAXLClientBase
     private $obuffer = "";
     private $compressed = false;
 
-    private $recv_bytes = 0;
-    private $send_bytes = 0;
-
     /** @var callable */
     private $recv_cb = null;
     private $recv_chunk_size = 1024;
@@ -223,11 +220,8 @@ class JAXLSocketClient implements JAXLClientBase
             }
         }
 
-        $this->recv_bytes += $bytes;
-        $total = $this->ibuffer.$raw;
-
         $this->ibuffer = "";
-        JAXLLogger::debug("read ".$bytes."/".$this->recv_bytes." of data");
+        JAXLLogger::debug("read $bytes bytes of data");
         if ($bytes > 0) {
             JAXLLogger::debug($raw);
         }
@@ -243,9 +237,8 @@ class JAXLSocketClient implements JAXLClientBase
         //JAXLLogger::debug("on write ready called");
         $total = strlen($this->obuffer);
         $bytes = @fwrite($fd, $this->obuffer);
-        $this->send_bytes += $bytes;
 
-        JAXLLogger::debug("sent ".$bytes."/".$this->send_bytes." of data");
+        JAXLLogger::debug("sent $bytes bytes of data");
         JAXLLogger::debug(substr($this->obuffer, 0, $bytes));
 
         $this->obuffer = substr($this->obuffer, $bytes, $total-$bytes);


### PR DESCRIPTION
More verbose logging messages and removed instance variables that hold total bytes that were transmitted over the wire, because that could easily cause integer overflow when XMPP connection is running for some time in the loop.